### PR TITLE
add py-psycopg2 to Dockerfile

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -9,6 +9,17 @@ ENV SSDEEP ssdeep-2.13
 # Install Cuckoo Sandbox Required Dependencies
 COPY requirements.txt /tmp/requirements.txt
 RUN apk add --no-cache tcpdump py-lxml py-chardet py-libvirt py-crypto curl
+RUN apk update && apk add --no-cache postgresql-dev \
+                       gcc \
+                       g++ \
+                       python-dev \
+                       libpq \
+                       py-pip \
+  && pip install --upgrade pip wheel \
+  && pip install psycopg2 \
+  && apk del --purge postgresql-dev \
+                     gcc \
+                     g++
 RUN apk add --no-cache -t .build-deps \
                            openssl-dev \
                            libxslt-dev \


### PR DESCRIPTION
When trying to use postgres database web service crash because psycopg2 is missing.
```
web_1            | ===> Use default ports and hosts if not specified...
web_1            | ES_HOST=elasticsearch
web_1            | ES_PORT=9200
web_1            | MONGO_HOST=mongo
web_1            | MONGO_TCP_PORT=27017
web_1            | POSTGRES_HOST=postgres
web_1            | POSTGRES_TCP_PORT=5432
web_1            | 
web_1            | ===> Update /cuckoo/conf/reporting.conf if needed...
web_1            | 
web_1            | ===> Waiting on elasticsearch(http://elasticsearch:9200) to start...
web_1            | Elasticsearch is ready!
web_1            | 
web_1            | ===> Waiting for MongoDB(mongo:27017) to start...Connection to mongo 27017 port [tcp/27017] succeeded!
web_1            | MongoDB is ready!
web_1            | 
web_1            | ===> Waiting for Postgres(postgres:5432) to start...Connection to postgres 5432 port [tcp/postgresql] succeeded!
web_1            | Postgres is ready!
web_1            | Traceback (most recent call last):
web_1            |   File "/usr/bin/cuckoo", line 11, in <module>
web_1            |     load_entry_point('Cuckoo==2.0.2', 'console_scripts', 'cuckoo')()
web_1            |   File "/usr/lib/python2.7/site-packages/click/core.py", line 716, in __call__
web_1            |     return self.main(*args, **kwargs)
web_1            |   File "/usr/lib/python2.7/site-packages/click/core.py", line 696, in main
web_1            |     rv = self.invoke(ctx)
web_1            |   File "/usr/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
web_1            |     return _process_result(sub_ctx.command.invoke(sub_ctx))
web_1            |   File "/usr/lib/python2.7/site-packages/click/core.py", line 889, in invoke
web_1            |     return ctx.invoke(self.callback, **ctx.params)
web_1            |   File "/usr/lib/python2.7/site-packages/click/core.py", line 534, in invoke
web_1            |     return callback(*args, **kwargs)
web_1            |   File "/usr/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
web_1            |     return f(get_current_context(), *args, **kwargs)
web_1            |   File "/usr/lib/python2.7/site-packages/cuckoo/main.py", line 488, in web
web_1            |     Database().connect()
web_1            |   File "/usr/lib/python2.7/site-packages/cuckoo/core/database.py", line 434, in connect
web_1            |     self._connect_database(dsn)   
web_1            |   File "/usr/lib/python2.7/site-packages/cuckoo/core/database.py", line 519, in _connect_database
web_1            |     "Missing PostgreSQL database driver (install with "
web_1            | cuckoo.common.exceptions.CuckooDependencyError: Missing PostgreSQL database driver (install with `pip install psycopg2`)
```

Adding psycopg2 to requirements.txt and rebuilding the image will fail because pg_config is missing:
```
Collecting psycopg2 (from -r /tmp/requirements_web.txt (line 1))
  Downloading psycopg2-2.7.1.tar.gz (421kB)
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found

    Error: pg_config executable not found.

    Please add the directory containing pg_config to the PATH
    or specify the full executable path with the option:

        python setup.py build_ext --pg-config /path/to/pg_config build ...

    or with the pg_config option in 'setup.cfg'.

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-wcBI9x/psycopg2/
```

```pg_config``` is missing because ```libpq-dev``` is not installed.
The image comes from ```blacktop/volatility:2.6``` which comes from on ```blacktop/yara:3.5``` which comes from ```alpine:3.5```.
Although ```libpq``` is available, package ```libpq-dev``` is missing from alpine.
https://bugs.alpinelinux.org/issues/3642

Without ```libpq-dev``` we have to use the full version, ```postgresql-dev``` to install psycopg2. We can install it, compile psycopg2 and then remove it.
What we need of libpq-dev is pg_config bins, but just in order to compile
psycopg2 and not for its regular use.
If I add postgresql-dev in the long apk add line I get:

``` 
 ERROR: unsatisfiable constraints:
  openssl-dev-1.0.2k-r0:
    conflicts: 
               libressl-dev-2.4.4-r0[pc:libcrypto=1.0.2k]
               libressl-dev-2.4.4-r0[pc:libssl=1.0.2k]
               libressl-dev-2.4.4-r0[pc:openssl=1.0.2k]
  libressl-dev-2.4.4-r0:
    conflicts: 
               openssl-dev-1.0.2k-r0[pc:libcrypto=2.4.4]
               openssl-dev-1.0.2k-r0[pc:libssl=2.4.4]
               openssl-dev-1.0.2k-r0[pc:openssl=2.4.4]
    satisfies: 
               postgresql-dev-9.6.2-r0[libressl-dev]
   .build-deps-0:
    masked in: cache
    satisfies: world[.build-deps]
```

The fix was to install postgresql-dev before openssl, use it to install psycopg2 and then remove it.

```
RUN apk add --no-cache postgresql-dev \
                       gcc \
                       g++ \
                       python-dev \
                       libpq \
                       py-pip \
  && pip install --upgrade pip wheel \
  && pip install psycopg2 \
  && apk del --purge postgresql-dev \
                     gcc \
                     g++

```