### PR TITLE
Apply small fixes

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -2,7 +2,7 @@ FROM blacktop/volatility:2.6
 
 LABEL maintainer "https://github.com/blacktop"
 
-ENV CUCKOO_VERSION 2.0.4
+ENV CUCKOO_VERSION 2.0.5.1
 ENV CUCKOO_CWD /cuckoo
 ENV SSDEEP 2.14.1
 

--- a/2.0/conf/cuckoo.conf
+++ b/2.0/conf/cuckoo.conf
@@ -2,7 +2,7 @@
 # Enable or disable startup version check. When enabled, Cuckoo will connect
 # to a remote location to verify whether the running version is the latest
 # one available.
-version_check = yes
+version_check = no
 
 # If turned on, Cuckoo will delete the original file after its analysis
 # has been completed.

--- a/2.0/docker-entrypoint.sh
+++ b/2.0/docker-entrypoint.sh
@@ -127,6 +127,7 @@ if [ "$1" = 'daemon' -a "$(id -u)" = '0' ]; then
   # Change the ownership of /cuckoo to cuckoo
   chown -R cuckoo:cuckoo /cuckoo
   cd /cuckoo
+  rm -rf pidfiles/*.pid
 
   set -- su-exec cuckoo /sbin/tini -- cuckoo -d "$@"
 


### PR DESCRIPTION
Hey there,

I tried to improve and fix a couple of things: 
* Update Cuckoo version to 2.0.5.1 (latest at the time of writing)
* Remove irrelevant cuckoo update to the latest version on start
* Remove `$CWD/pidfiles/*.pid` in the entrypoint to be able to restart a daemon container without the error `[cuckoo] ERROR: Cuckoo is already running. PID: 1`

Cheers!