### PR TITLE
Mount analyses folder to avoid an error on the startup

### DIFF
--- a/docker-compose.vbox.yml
+++ b/docker-compose.vbox.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./cuckoo-tmp/:/tmp/cuckoo-tmp/
       - /mnt/cuckoo-storage/:/cuckoo/storage/
+      - /mnt/cuckoo-storage/analyses/:/cuckoo/storage/analyses/
       - ./vbox/conf/:/cuckoo/conf/
     env_file:
       - ./2.0/config-file.env


### PR DESCRIPTION
On initial docker-compose up I observed the following error in a cuckoo container:
```
cuckoo_1         | 
cuckoo_1         | 2018-04-11 16:23:24,212 [cuckoo] ERROR: OSError: [Errno 2] No such file or directory: '/cuckoo/storage/analyses'
cuckoo_1         | Traceback (most recent call last):
cuckoo_1         |   File "/usr/lib/python2.7/site-packages/cuckoo/main.py", line 231, in main
cuckoo_1         |     cuckoo_main(maxcount)
cuckoo_1         |   File "/usr/lib/python2.7/site-packages/cuckoo/main.py", line 179, in cuckoo_main
cuckoo_1         |     sched.start()
cuckoo_1         |   File "/usr/lib/python2.7/site-packages/cuckoo/core/scheduler.py", line 902, in start
cuckoo_1         |     dir_stats = os.statvfs(dir_path.encode("utf8"))
cuckoo_1         | OSError: [Errno 2] No such file or directory: '/cuckoo/storage/analyses'
```

So we can fix this by mounting the analyses folder explicitly.